### PR TITLE
feat: add charging symbol to battery swipe view

### DIFF
--- a/DynamicIslandWindow.qml
+++ b/DynamicIslandWindow.qml
@@ -822,6 +822,7 @@ PanelWindow {
                     id: itemId,
                     kind: "battery",
                     level: Math.max(0, Math.min(100, batteryCapacity)),
+                    isCharging: isCharging,
                     icon: "",
                     text: Math.max(0, batteryCapacity) + "%"
                 };
@@ -888,6 +889,7 @@ PanelWindow {
                     + "\u001f" + String(item.icon || "")
                     + "\u001f" + String(item.text || "")
                     + "\u001f" + String(item.level === undefined ? "" : item.level)
+                    + "\u001f" + String(item.isCharging === undefined ? "" : item.isCharging)
                     + "\u001e";
             }
 

--- a/SwipeCustomInfoLayer.qml
+++ b/SwipeCustomInfoLayer.qml
@@ -96,7 +96,8 @@ Item {
                 readonly property bool hasLeadingVisual: hasIcon || isBattery
                 implicitWidth: isCava
                     ? cavaBars.implicitWidth
-                    : leadingVisual.width + (hasLeadingVisual ? root.iconSpacing : 0) + valueText.implicitWidth
+                    : (isBattery && modelData.isCharging ? (chargingIcon.implicitWidth + 4) : 0)
+                      + leadingVisual.width + (hasLeadingVisual ? root.iconSpacing : 0) + valueText.implicitWidth
                 implicitHeight: root.height
                 width: implicitWidth
                 height: implicitHeight
@@ -106,6 +107,17 @@ Item {
                     visible: parent.isCava
                     anchors.centerIn: parent
                     levels: root.cavaLevels
+                }
+
+                Text {
+                    id: chargingIcon
+                    visible: parent.isBattery && modelData.isCharging
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: userConfig.statusIcons["charging"]
+                    color: "white"
+                    font.pixelSize: root.iconPixelSize - 1
+                    font.family: root.iconFontFamily
                 }
 
                 Item {
@@ -178,8 +190,12 @@ Item {
                 Text {
                     visible: !parent.isCava
                     id: valueText
-                    anchors.left: parent.isBattery ? parent.left : leadingVisual.right
-                    anchors.leftMargin: parent.hasLeadingVisual && !parent.isBattery ? root.iconSpacing : 0
+                    anchors.left: parent.isBattery 
+                        ? (chargingIcon.visible ? chargingIcon.right : parent.left)
+                        : leadingVisual.right
+                    anchors.leftMargin: (parent.isBattery && chargingIcon.visible) 
+                        ? 4 
+                        : (parent.hasLeadingVisual && !parent.isBattery ? root.iconSpacing : 0)
                     anchors.verticalCenter: parent.verticalCenter
                     text: modelData.text || ""
                     color: "white"


### PR DESCRIPTION
Description: This PR adds a charging symbol (bolt icon) to the "cava + battery" swipe view, providing visual feedback when the device is charging. This matches the design used in the control center panel for consistency.

<img width="274" height="56" alt="image" src="https://github.com/user-attachments/assets/6ae582ee-b49e-48ea-8239-7cacea76e398" />

Hope it helps :smile: 