### PR TITLE
[codex] Ensure user config JSON exists

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: whysooraj <whysooraj.official@gmail.com>
 pkgname=tide-island
-_srcdir=Tide-island-1.0.4
-pkgver=1.0.4
+_srcdir=Tide-island-1.0.5
+pkgver=1.0.5
 pkgrel=1
 pkgdesc="A dynamic island for Hyprland using Quickshell"
 arch=('x86_64')

--- a/bin/tide-island-setup
+++ b/bin/tide-island-setup
@@ -55,15 +55,35 @@ def load_user_config() -> dict:
     path = user_config_path()
     try:
         with path.open("r", encoding="utf-8") as file:
-            data = json.load(file)
+            text = file.read()
     except FileNotFoundError:
-        return {}
-    except json.JSONDecodeError:
+        ensure_user_config_file()
         return {}
     except OSError:
         return {}
 
+    if not text.strip():
+        ensure_user_config_file()
+        return {}
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+
     return data if isinstance(data, dict) else {}
+
+
+def ensure_user_config_file() -> None:
+    path = user_config_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.chmod(0o700)
+        if path.exists() and path.read_text(encoding="utf-8").strip():
+            return
+        save_user_config({})
+    except OSError:
+        pass
 
 
 def save_user_config(data: dict) -> None:


### PR DESCRIPTION
## What changed

- Create `~/.config/tide-island/userconfig.json` with `{}` when the setup helper sees that it is missing.
- Repair an empty or whitespace-only `userconfig.json` the same way.
- Preserve existing non-empty config files, including invalid JSON, so user content is not overwritten.
- Bump the packaged release metadata to `1.0.5` so AUR can point at a stable tag containing the fix.

## Why

`UserConfig.qml` reads the per-user JSON config path, but a fresh install may not have that file yet. The setup helper already runs on startup, so this adds the lowest-cost place to create the file once without adding a watcher, loop, or extra background process.

## Validation

- `python -m py_compile bin/tide-island-setup`
- Fresh temp config dir: `bin/tide-island-setup --check` creates `tide-island/userconfig.json` containing `{}` with mode `600`.
- Empty temp config file: `bin/tide-island-setup --check` rewrites it to `{}` with mode `600`.
- Existing non-empty config file remains unchanged.
- `makepkg --printsrcinfo` shows `pkgver = 1.0.5` and the `1.0.5` tag source URL.