### PR TITLE
[codex] Improve lyrics matching

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: whysooraj <whysooraj.official@gmail.com>
 pkgname=tide-island
-_srcdir=Tide-island-1.0.5
-pkgver=1.0.5
+_srcdir=Tide-island-1.0.6
+pkgver=1.0.6
 pkgrel=1
 pkgdesc="A dynamic island for Hyprland using Quickshell"
 arch=('x86_64')

--- a/bin/tide-island-setup
+++ b/bin/tide-island-setup
@@ -55,15 +55,35 @@ def load_user_config() -> dict:
     path = user_config_path()
     try:
         with path.open("r", encoding="utf-8") as file:
-            data = json.load(file)
+            text = file.read()
     except FileNotFoundError:
-        return {}
-    except json.JSONDecodeError:
+        ensure_user_config_file()
         return {}
     except OSError:
         return {}
 
+    if not text.strip():
+        ensure_user_config_file()
+        return {}
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+
     return data if isinstance(data, dict) else {}
+
+
+def ensure_user_config_file() -> None:
+    path = user_config_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.chmod(0o700)
+        if path.exists() and path.read_text(encoding="utf-8").strip():
+            return
+        save_user_config({})
+    except OSError:
+        pass
 
 
 def save_user_config(data: dict) -> None:

--- a/lyricsmpris/LyricsCore.cpp
+++ b/lyricsmpris/LyricsCore.cpp
@@ -8,6 +8,20 @@
 namespace lyricsmpris {
 namespace {
 
+constexpr double kTitleSimilarityThreshold = 0.72;
+constexpr double kArtistSimilarityThreshold = 0.60;
+constexpr int kAcceptedScore = 72;
+constexpr int kAcceptedPlainScore = 68;
+constexpr int kHighConfidenceScore = 92;
+
+enum VersionFlag {
+    VersionLive = 1 << 0,
+    VersionCover = 1 << 1,
+    VersionInstrumental = 1 << 2,
+    VersionRemix = 1 << 3,
+    VersionSpeed = 1 << 4
+};
+
 QString stringValue(const QJsonObject &object, const QString &key) {
     const QJsonValue value = object.value(key);
     if (value.isString()) return value.toString();
@@ -41,6 +55,191 @@ QString firstNonEmpty(const QStringList &values) {
         if (!value.trimmed().isEmpty()) return value;
     }
     return QString();
+}
+
+QString normalizeCjkVariants(QString value) {
+    const QString traditional = QStringLiteral("氣傑倫鄧劉風後來闊聽裡裏愛詞編讓難貴葉營擁親輕說願戀記飄夢攪謝準備嗎嚐錯誰飛鋼純樂現場與對這個為萬無聲體會妳臺灣國語簡髮長過開關點畫麥麵黃");
+    const QString simplified = QStringLiteral("气杰伦邓刘风后来阔听里里爱词编让难贵叶营拥亲轻说愿恋记飘梦搅谢准备吗尝错谁飞钢纯乐现场与对这个为万无声体会你台湾国语简发长过开关点画麦面黄");
+
+    for (QChar &character : value) {
+        const qsizetype index = traditional.indexOf(character);
+        if (index >= 0 && index < simplified.size()) character = simplified.at(index);
+    }
+    return value;
+}
+
+bool containsAny(const QString &value, const QStringList &needles) {
+    for (const QString &needle : needles) {
+        if (!needle.isEmpty() && value.contains(needle)) return true;
+    }
+    return false;
+}
+
+bool isPlaceholderLyricText(QString text) {
+    text = normalizeCjkVariants(text.toLower());
+    text.remove(QRegularExpression(QStringLiteral(R"(\s+)")));
+    return text == QStringLiteral("暂无歌词")
+        || text == QStringLiteral("暂无")
+        || text.contains(QStringLiteral("纯音乐"))
+        || text.contains(QStringLiteral("没有填词"))
+        || text.contains(QStringLiteral("instrumental"));
+}
+
+bool isCjk(QChar character) {
+    const uint code = character.unicode();
+    return (code >= 0x3400 && code <= 0x4dbf)
+        || (code >= 0x4e00 && code <= 0x9fff)
+        || (code >= 0xf900 && code <= 0xfaff);
+}
+
+bool hasCjk(const QString &value) {
+    for (QChar character : value) {
+        if (isCjk(character)) return true;
+    }
+    return false;
+}
+
+bool hasLatin(const QString &value) {
+    for (QChar character : value) {
+        if (character.script() == QChar::Script_Latin) return true;
+    }
+    return false;
+}
+
+QStringList comparisonUnits(const QString &normalizedValue) {
+    QStringList units;
+    const QStringList words = normalizedValue.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    for (const QString &word : words) {
+        if (word == QLatin1String("the")
+            || word == QLatin1String("and")
+            || word == QLatin1String("a")
+            || word == QLatin1String("an")) {
+            continue;
+        }
+
+        QString latinRun;
+        auto flushLatinRun = [&units, &latinRun]() {
+            if (!latinRun.isEmpty()) {
+                units.append(latinRun);
+                latinRun.clear();
+            }
+        };
+
+        for (QChar character : word) {
+            if (isCjk(character)) {
+                flushLatinRun();
+                units.append(QString(character));
+            } else if (character.isLetterOrNumber()) {
+                latinRun.append(character);
+            } else {
+                flushLatinRun();
+            }
+        }
+        flushLatinRun();
+    }
+
+    units.removeDuplicates();
+    return units;
+}
+
+double unitSimilarity(const QString &left, const QString &right, bool titleMode) {
+    const QString normalizedLeft = titleMode ? normalizedTitle(left) : normalizedArtist(left);
+    const QString normalizedRight = titleMode ? normalizedTitle(right) : normalizedArtist(right);
+    if (normalizedLeft.isEmpty() || normalizedRight.isEmpty()) return 0.0;
+    if (normalizedLeft == normalizedRight) return 1.0;
+
+    const QStringList leftUnits = comparisonUnits(normalizedLeft);
+    const QStringList rightUnits = comparisonUnits(normalizedRight);
+    if (leftUnits.isEmpty() || rightUnits.isEmpty()) return 0.0;
+
+    int common = 0;
+    for (const QString &unit : leftUnits) {
+        if (rightUnits.contains(unit)) common++;
+    }
+
+    return (2.0 * common) / double(leftUnits.size() + rightUnits.size());
+}
+
+bool unitsContainAll(const QString &needle, const QString &haystack, bool titleMode) {
+    const QString normalizedNeedle = titleMode ? normalizedTitle(needle) : normalizedArtist(needle);
+    const QString normalizedHaystack = titleMode ? normalizedTitle(haystack) : normalizedArtist(haystack);
+    const QStringList needleUnits = comparisonUnits(normalizedNeedle);
+    const QStringList haystackUnits = comparisonUnits(normalizedHaystack);
+    if (needleUnits.isEmpty() || haystackUnits.isEmpty()) return false;
+
+    for (const QString &unit : needleUnits) {
+        if (!haystackUnits.contains(unit)) return false;
+    }
+    return true;
+}
+
+bool sameComparableScript(const QString &left, const QString &right) {
+    const QString normalizedLeft = normalizeCjkVariants(left.toLower());
+    const QString normalizedRight = normalizeCjkVariants(right.toLower());
+    return (hasCjk(normalizedLeft) && hasCjk(normalizedRight))
+        || (hasLatin(normalizedLeft) && hasLatin(normalizedRight));
+}
+
+int versionFlagsFor(QString value) {
+    value = normalizeCjkVariants(value.toLower());
+
+    int flags = 0;
+    if (value.contains(QRegularExpression(QStringLiteral(R"(\blive\b)")))
+        || containsAny(value, {
+            QStringLiteral("演唱会"),
+            QStringLiteral("现场"),
+            QStringLiteral("巡回"),
+            QStringLiteral("concert")
+        })) {
+        flags |= VersionLive;
+    }
+    if (value.contains(QRegularExpression(QStringLiteral(R"(\bcover\b)")))
+        || containsAny(value, {
+            QStringLiteral("翻唱"),
+            QStringLiteral("原唱")
+        })) {
+        flags |= VersionCover;
+    }
+    if (containsAny(value, {
+            QStringLiteral("instrumental"),
+            QStringLiteral("伴奏"),
+            QStringLiteral("纯音乐"),
+            QStringLiteral("钢琴"),
+            QStringLiteral("piano"),
+            QStringLiteral("karaoke")
+        })) {
+        flags |= VersionInstrumental;
+    }
+    if (value.contains(QRegularExpression(QStringLiteral(R"(\bremix\b)")))
+        || containsAny(value, {
+            QStringLiteral("dj版"),
+            QStringLiteral("dj 版"),
+            QStringLiteral("混音")
+        })) {
+        flags |= VersionRemix;
+    }
+    if (containsAny(value, {
+            QStringLiteral("加速"),
+            QStringLiteral("降速"),
+            QStringLiteral("变速"),
+            QStringLiteral("sped up"),
+            QStringLiteral("slowed")
+        })) {
+        flags |= VersionSpeed;
+    }
+    return flags;
+}
+
+QString lyricTextForMetadata(const ProviderCandidate &candidate) {
+    return (candidate.syncedLyrics + QLatin1Char('\n') + candidate.plainLyrics).trimmed();
+}
+
+int pointsForSimilarity(double similarity, int maxPoints) {
+    return int(similarity * maxPoints + 0.5);
+}
+
+QString reasonWithScore(const QString &reason, int score) {
+    return reason + QStringLiteral(":") + QString::number(score);
 }
 
 QList<ProviderCandidate> parseLrclibObject(const QJsonObject &object) {
@@ -104,10 +303,17 @@ QString normalizeCommon(QString value, bool titleMode) {
     value.replace(QStringLiteral("&quot;"), QStringLiteral("\""));
     value.replace(QStringLiteral("&#39;"), QStringLiteral("'"));
 
+    if (titleMode)
+        value.remove(QRegularExpression(QStringLiteral(R"(^\s*\d{1,3}\s*[\.\-_\)]\s*)")));
+
     const QRegularExpression noisyBrackets(
         QStringLiteral(R"((\(|\[|\{)[^\)\]\}]*\b(feat|ft\.?|featuring|with|remaster(?:ed)?|live|mono|stereo|explicit|clean|radio|edit|version|official|audio|video|lyrics?|mv|hd)\b[^\)\]\}]*(\)|\]|\}))"),
         QRegularExpression::CaseInsensitiveOption);
     value.remove(noisyBrackets);
+    const QRegularExpression localizedNoisyBrackets(
+        QStringLiteral(R"([（【［\[][^）】\]\[]*(?:cover|live|remix|伴奏|钢琴|鋼琴|纯音乐|純音樂|翻唱|原唱|加速|降速|混音|现场|現場|演唱会|演唱會|版)[^）】\]\[]*[）】\]\]])"),
+        QRegularExpression::CaseInsensitiveOption);
+    value.remove(localizedNoisyBrackets);
 
     if (titleMode) {
         const QRegularExpression suffixNoise(
@@ -122,7 +328,7 @@ QString normalizeCommon(QString value, bool titleMode) {
     value.remove(featuring);
     value.replace(QRegularExpression(QStringLiteral(R"([^\p{L}\p{N}]+)")), QStringLiteral(" "));
     value.replace(QRegularExpression(QStringLiteral(R"(\s+)")), QStringLiteral(" "));
-    return value.trimmed();
+    return normalizeCjkVariants(value).trimmed();
 }
 
 QString jsonLyricValue(const QJsonObject &object) {
@@ -147,6 +353,10 @@ bool LyricDocument::hasPlainLines() const {
 
 bool LyricDocument::isEmpty() const {
     return syncedLines.isEmpty() && plainLines.isEmpty() && !instrumental;
+}
+
+bool LyricMetadata::isEmpty() const {
+    return title.trimmed().isEmpty() && artist.trimmed().isEmpty() && album.trimmed().isEmpty();
 }
 
 void LyricDocument::clearAndFree() {
@@ -179,16 +389,39 @@ QString normalizedArtist(QString artist) {
 }
 
 QStringList significantTokens(const QString &value) {
-    QStringList tokens = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    QStringList tokens = comparisonUnits(value);
     tokens.erase(std::remove_if(tokens.begin(), tokens.end(), [](const QString &token) {
-        return token.size() < 2
-            || token == QLatin1String("the")
+        return token == QLatin1String("the")
             || token == QLatin1String("and")
             || token == QLatin1String("a")
             || token == QLatin1String("an");
     }), tokens.end());
     tokens.removeDuplicates();
     return tokens;
+}
+
+LyricMetadata lyricMetadataFromText(const QString &lyrics) {
+    LyricMetadata metadata;
+    QString source = lyrics;
+    source.replace(QStringLiteral("\r\n"), QStringLiteral("\n"));
+    source.replace(QLatin1Char('\r'), QLatin1Char('\n'));
+
+    const QRegularExpression metadataExpression(
+        QStringLiteral(R"(^\s*\[([a-zA-Z][a-zA-Z0-9_+\-]*)\s*:\s*([^\]]*)\]\s*$)"));
+    const QStringList rows = source.split(QLatin1Char('\n'));
+    for (const QString &rawRow : rows) {
+        const QRegularExpressionMatch match = metadataExpression.match(rawRow.trimmed());
+        if (!match.hasMatch()) continue;
+
+        const QString key = match.captured(1).toLower();
+        const QString value = cleanLyricText(match.captured(2));
+        if (value.isEmpty()) continue;
+
+        if (key == QLatin1String("ti") && metadata.title.isEmpty()) metadata.title = value;
+        else if (key == QLatin1String("ar") && metadata.artist.isEmpty()) metadata.artist = value;
+        else if (key == QLatin1String("al") && metadata.album.isEmpty()) metadata.album = value;
+    }
+    return metadata;
 }
 
 LyricDocument parseLyrics(const QString &lyrics, const QString &provider) {
@@ -230,12 +463,13 @@ LyricDocument parseLyrics(const QString &lyrics, const QString &provider) {
             QString text = row;
             text.remove(timestampExpression);
             text = cleanLyricText(text);
+            if (isPlaceholderLyricText(text)) continue;
             for (qint64 timestamp : timestamps) document.syncedLines.append({timestamp, text});
             continue;
         }
 
         const QString plain = cleanLyricText(row);
-        if (!plain.isEmpty()) document.plainLines.append(plain);
+        if (!plain.isEmpty() && !isPlaceholderLyricText(plain)) document.plainLines.append(plain);
     }
 
     std::stable_sort(document.syncedLines.begin(), document.syncedLines.end(), [](const LyricLine &left, const LyricLine &right) {
@@ -273,67 +507,131 @@ QString selectLineAt(const LyricDocument &document, qint64 positionMs) {
     return document.plainLines.isEmpty() ? QString() : document.plainLines.first();
 }
 
+CandidateEvaluation evaluateCandidate(const TrackQuery &query, const ProviderCandidate &candidate) {
+    CandidateEvaluation evaluation;
+    evaluation.lyricMetadata = lyricMetadataFromText(lyricTextForMetadata(candidate));
+
+    if (normalizedTitle(query.title).isEmpty()) {
+        evaluation.reason = QStringLiteral("missing_query_title");
+        return evaluation;
+    }
+
+    const int queryVersionFlags = versionFlagsFor(query.title + QLatin1Char(' ') + query.album);
+    int candidateVersionFlags = versionFlagsFor(candidate.title + QLatin1Char(' ') + candidate.album);
+    if (candidate.instrumental) candidateVersionFlags |= VersionInstrumental;
+    const int unexpectedVersionFlags = candidateVersionFlags & ~queryVersionFlags;
+    if (unexpectedVersionFlags != 0) {
+        evaluation.reason = QStringLiteral("version_mismatch");
+        return evaluation;
+    }
+
+    double bestTitleSimilarity = 0.0;
+    bool hasTitleEvidence = false;
+    if (candidate.metadataTrusted && !candidate.title.trimmed().isEmpty()) {
+        const double similarity = unitSimilarity(query.title, candidate.title, true);
+        if (similarity < kTitleSimilarityThreshold) {
+            evaluation.reason = QStringLiteral("title_mismatch");
+            return evaluation;
+        }
+        bestTitleSimilarity = std::max(bestTitleSimilarity, similarity);
+        hasTitleEvidence = true;
+    }
+    if (!evaluation.lyricMetadata.title.trimmed().isEmpty()) {
+        const double similarity = unitSimilarity(query.title, evaluation.lyricMetadata.title, true);
+        if (similarity < kTitleSimilarityThreshold) {
+            evaluation.reason = QStringLiteral("lyric_title_mismatch");
+            return evaluation;
+        }
+        bestTitleSimilarity = std::max(bestTitleSimilarity, similarity);
+        hasTitleEvidence = true;
+    }
+    if (!hasTitleEvidence) {
+        evaluation.reason = candidate.metadataTrusted
+            ? QStringLiteral("missing_candidate_title")
+            : QStringLiteral("untrusted_metadata");
+        return evaluation;
+    }
+
+    double bestArtistSimilarity = 0.0;
+    bool hasArtistEvidence = false;
+    if (!query.artist.trimmed().isEmpty()) {
+        if (candidate.metadataTrusted && !candidate.artist.trimmed().isEmpty()) {
+            double similarity = unitSimilarity(query.artist, candidate.artist, false);
+            const bool listedArtist = unitsContainAll(query.artist, candidate.artist, false);
+            if (similarity < kArtistSimilarityThreshold && !listedArtist && sameComparableScript(query.artist, candidate.artist)) {
+                evaluation.reason = QStringLiteral("artist_mismatch");
+                return evaluation;
+            }
+            if (listedArtist) similarity = std::max(similarity, 0.92);
+            bestArtistSimilarity = std::max(bestArtistSimilarity, similarity);
+            hasArtistEvidence = true;
+        }
+        if (!evaluation.lyricMetadata.artist.trimmed().isEmpty()) {
+            double similarity = unitSimilarity(query.artist, evaluation.lyricMetadata.artist, false);
+            const bool listedArtist = unitsContainAll(query.artist, evaluation.lyricMetadata.artist, false);
+            if (similarity < kArtistSimilarityThreshold && !listedArtist && sameComparableScript(query.artist, evaluation.lyricMetadata.artist)) {
+                evaluation.reason = QStringLiteral("lyric_artist_mismatch");
+                return evaluation;
+            }
+            if (listedArtist) similarity = std::max(similarity, 0.92);
+            bestArtistSimilarity = std::max(bestArtistSimilarity, similarity);
+            hasArtistEvidence = true;
+        }
+    }
+
+    evaluation.score += pointsForSimilarity(bestTitleSimilarity, 60);
+    if (hasArtistEvidence) evaluation.score += pointsForSimilarity(bestArtistSimilarity, 25);
+
+    double bestAlbumSimilarity = 0.0;
+    if (!query.album.trimmed().isEmpty()) {
+        if (candidate.metadataTrusted && !candidate.album.trimmed().isEmpty())
+            bestAlbumSimilarity = std::max(bestAlbumSimilarity, unitSimilarity(query.album, candidate.album, true));
+        if (!evaluation.lyricMetadata.album.trimmed().isEmpty())
+            bestAlbumSimilarity = std::max(bestAlbumSimilarity, unitSimilarity(query.album, evaluation.lyricMetadata.album, true));
+        if (bestAlbumSimilarity >= 0.60) evaluation.score += pointsForSimilarity(bestAlbumSimilarity, 8);
+    }
+
+    if (query.durationMs > 0) {
+        if (candidate.durationMs > 0) {
+            const int delta = std::abs(query.durationMs - candidate.durationMs);
+            const bool versioned = (queryVersionFlags | candidateVersionFlags) != 0;
+            const int tolerance = std::max(versioned ? 30000 : 15000, int(query.durationMs * (versioned ? 0.15 : 0.08)));
+            if (delta > tolerance) {
+                evaluation.reason = QStringLiteral("duration_mismatch");
+                return evaluation;
+            }
+
+            if (delta <= 2000) evaluation.score += 20;
+            else if (delta <= 5000) evaluation.score += 15;
+            else if (delta <= 10000) evaluation.score += 10;
+            else evaluation.score += 5;
+        } else if (query.durationMs < 90000) {
+            evaluation.reason = QStringLiteral("missing_candidate_duration");
+            return evaluation;
+        }
+    }
+
+    if (!candidate.syncedLyrics.isEmpty()) evaluation.score += 8;
+    else if (!candidate.plainLyrics.isEmpty()) evaluation.score += 2;
+    if (candidate.instrumental) evaluation.score += 4;
+
+    const int acceptScore = !candidate.syncedLyrics.isEmpty() || candidate.instrumental
+        ? kAcceptedScore
+        : kAcceptedPlainScore;
+    evaluation.accepted = evaluation.score >= acceptScore;
+    evaluation.highConfidence = evaluation.accepted
+        && evaluation.score >= kHighConfidenceScore
+        && bestTitleSimilarity >= 0.92
+        && (query.artist.trimmed().isEmpty() || bestArtistSimilarity >= 0.90)
+        && (query.durationMs <= 0 || candidate.durationMs > 0);
+    evaluation.reason = evaluation.accepted
+        ? QStringLiteral("accepted")
+        : reasonWithScore(QStringLiteral("score_below_threshold"), evaluation.score);
+    return evaluation;
+}
+
 int scoreCandidate(const TrackQuery &query, const ProviderCandidate &candidate) {
-    const QString queryTitle = normalizedTitle(query.title);
-    const QString candidateTitle = normalizedTitle(candidate.title);
-    if (queryTitle.isEmpty()) return 0;
-
-    int score = 0;
-    if (!candidateTitle.isEmpty()) {
-        if (candidateTitle == queryTitle) score += 60;
-        else if (candidateTitle.contains(queryTitle) || queryTitle.contains(candidateTitle)) score += 44;
-        else {
-            const QStringList queryTokens = significantTokens(queryTitle);
-            const QStringList candidateTokens = significantTokens(candidateTitle);
-            int common = 0;
-            for (const QString &token : queryTokens) {
-                if (candidateTokens.contains(token)) common++;
-            }
-            if (!queryTokens.isEmpty()) score += (common * 38) / queryTokens.size();
-        }
-    } else {
-        score += 35;
-    }
-
-    const QString queryArtist = normalizedArtist(query.artist);
-    const QString candidateArtist = normalizedArtist(candidate.artist);
-    if (!queryArtist.isEmpty() && !candidateArtist.isEmpty()) {
-        if (candidateArtist == queryArtist) score += 25;
-        else if (candidateArtist.contains(queryArtist) || queryArtist.contains(candidateArtist)) score += 20;
-        else {
-            const QStringList queryTokens = significantTokens(queryArtist);
-            const QStringList candidateTokens = significantTokens(candidateArtist);
-            int common = 0;
-            for (const QString &token : queryTokens) {
-                if (candidateTokens.contains(token)) common++;
-            }
-            if (!queryTokens.isEmpty()) score += (common * 18) / queryTokens.size();
-        }
-    } else if (queryArtist.isEmpty() || candidateArtist.isEmpty()) {
-        score += 6;
-    }
-
-    const QString queryAlbum = normalizedTitle(query.album);
-    const QString candidateAlbum = normalizedTitle(candidate.album);
-    if (!queryAlbum.isEmpty() && !candidateAlbum.isEmpty()) {
-        if (candidateAlbum == queryAlbum) score += 8;
-        else if (candidateAlbum.contains(queryAlbum) || queryAlbum.contains(candidateAlbum)) score += 5;
-    }
-
-    if (query.durationMs > 0 && candidate.durationMs > 0) {
-        const int delta = std::abs(query.durationMs - candidate.durationMs);
-        if (delta <= 2000) score += 20;
-        else if (delta <= 5000) score += 14;
-        else if (delta <= 10000) score += 8;
-        else if (delta <= 20000) score += 3;
-    } else {
-        score += 3;
-    }
-
-    if (!candidate.syncedLyrics.isEmpty()) score += 10;
-    else if (!candidate.plainLyrics.isEmpty()) score += 3;
-    if (candidate.instrumental) score += 5;
-    return score;
+    return evaluateCandidate(query, candidate).score;
 }
 
 QList<ProviderCandidate> parseLrclibJson(const QByteArray &payload) {
@@ -384,8 +682,11 @@ QList<ProviderCandidate> parseNeteaseSearchJson(const QByteArray &payload) {
         candidate.provider = QStringLiteral("netease");
         candidate.title = stringValue(song, QStringLiteral("name"));
         candidate.artist = artistsFromArray(song.value(QStringLiteral("artists")).toArray());
+        if (candidate.artist.isEmpty()) candidate.artist = artistsFromArray(song.value(QStringLiteral("ar")).toArray());
         candidate.album = stringValue(song.value(QStringLiteral("album")).toObject(), QStringLiteral("name"));
+        if (candidate.album.isEmpty()) candidate.album = stringValue(song.value(QStringLiteral("al")).toObject(), QStringLiteral("name"));
         candidate.durationMs = intValue(song, QStringLiteral("duration"));
+        if (candidate.durationMs <= 0) candidate.durationMs = intValue(song, QStringLiteral("dt"));
         candidate.syncedLyrics = stringValue(song, QStringLiteral("id"));
         if (!candidate.title.isEmpty() && !candidate.syncedLyrics.isEmpty()) candidates.append(candidate);
     }
@@ -523,6 +824,7 @@ QList<ProviderCandidate> parseMusixmatchJson(const QByteArray &payload, const QS
         .value(QStringLiteral("body")).toObject();
     ProviderCandidate candidate;
     candidate.provider = provider;
+    candidate.metadataTrusted = false;
 
     const QJsonObject subtitle = body.value(QStringLiteral("subtitle")).toObject();
     const QJsonObject lyrics = body.value(QStringLiteral("lyrics")).toObject();

--- a/lyricsmpris/LyricsCore.h
+++ b/lyricsmpris/LyricsCore.h
@@ -34,6 +34,14 @@ struct LyricDocument {
     void clearAndFree();
 };
 
+struct LyricMetadata {
+    QString title;
+    QString artist;
+    QString album;
+
+    bool isEmpty() const;
+};
+
 struct ProviderCandidate {
     QString provider;
     QString title;
@@ -43,15 +51,26 @@ struct ProviderCandidate {
     QString syncedLyrics;
     QString plainLyrics;
     bool instrumental = false;
+    bool metadataTrusted = true;
+};
+
+struct CandidateEvaluation {
+    int score = 0;
+    bool accepted = false;
+    bool highConfidence = false;
+    QString reason;
+    LyricMetadata lyricMetadata;
 };
 
 QString cleanLyricText(QString text);
 QString normalizedTitle(QString title);
 QString normalizedArtist(QString artist);
 QStringList significantTokens(const QString &value);
+LyricMetadata lyricMetadataFromText(const QString &lyrics);
 LyricDocument parseLyrics(const QString &lyrics, const QString &provider = QString());
 LyricDocument documentFromCandidate(const ProviderCandidate &candidate);
 QString selectLineAt(const LyricDocument &document, qint64 positionMs);
+CandidateEvaluation evaluateCandidate(const TrackQuery &query, const ProviderCandidate &candidate);
 int scoreCandidate(const TrackQuery &query, const ProviderCandidate &candidate);
 
 QList<ProviderCandidate> parseLrclibJson(const QByteArray &payload);

--- a/lyricsmpris/LyricsMprisApp.cpp
+++ b/lyricsmpris/LyricsMprisApp.cpp
@@ -27,8 +27,7 @@ constexpr int kPrimaryFallbackDelayMs = 1800;
 constexpr int kRefreshIntervalMs = 1500;
 constexpr int kPositionIntervalMs = 350;
 constexpr int kNetworkTimeoutMs = 7000;
-constexpr int kAcceptScore = 50;
-constexpr int kPlainScore = 42;
+constexpr int kDownloadCandidateLimit = 5;
 constexpr qsizetype kMaxLocalLyricsSize = 1024 * 1024;
 
 QStringList defaultProviders() {
@@ -76,6 +75,10 @@ QByteArray safeBody(QNetworkReply *reply) {
     return body.left(2 * 1024 * 1024);
 }
 
+bool lyricsDebugEnabled() {
+    return !qEnvironmentVariableIsEmpty("LYRICSMPRIS_DEBUG");
+}
+
 } // namespace
 
 LyricsMprisApp::LyricsMprisApp(AppOptions options, QObject *parent)
@@ -97,6 +100,11 @@ LyricsMprisApp::LyricsMprisApp(AppOptions options, QObject *parent)
 }
 
 void LyricsMprisApp::start() {
+    if (m_options.lookupMode) {
+        startLookup();
+        return;
+    }
+
     QDBusConnection bus = QDBusConnection::sessionBus();
     bus.connect(
         QStringLiteral("org.freedesktop.DBus"),
@@ -115,6 +123,18 @@ void LyricsMprisApp::start() {
 
     refreshPlayers();
     m_refreshTimer.start();
+}
+
+void LyricsMprisApp::startLookup() {
+    PlayerInfo player;
+    player.playbackStatus = QStringLiteral("Playing");
+    player.title = m_options.lookupTitle;
+    player.artist = m_options.lookupArtist;
+    player.album = m_options.lookupAlbum;
+    player.lengthMs = m_options.lookupDurationMs;
+    player.trackId = QStringLiteral("lookup");
+    player.valid = true;
+    startTrack(player);
 }
 
 void LyricsMprisApp::refreshPlayers() {
@@ -311,13 +331,16 @@ void LyricsMprisApp::startTrack(const PlayerInfo &player) {
     m_currentTrackKey = trackKeyFor(player);
     m_fallbackStarted = false;
     m_hasAcceptedDocument = false;
+    m_bestSyncedScore = 0;
     m_bestPlainScore = 0;
+    m_bestSyncedDocument.clearAndFree();
     m_bestPlainCandidate = ProviderCandidate();
     emitLine(QString(), false);
     emitStatus(QStringLiteral("searching"));
 
     if (player.title.trimmed().isEmpty()) {
         emitStatus(QStringLiteral("not_found"));
+        maybeQuitLookup();
         return;
     }
 
@@ -476,7 +499,7 @@ void LyricsMprisApp::startNetease() {
     urlQuery.addQueryItem(QStringLiteral("type"), QStringLiteral("1"));
     urlQuery.addQueryItem(QStringLiteral("limit"), QStringLiteral("5"));
     urlQuery.addQueryItem(QStringLiteral("offset"), QStringLiteral("0"));
-    get(withQuery(QStringLiteral("https://music.163.com/api/search/get/web"), urlQuery), QStringLiteral("netease"), QStringLiteral("netease-search"));
+    get(withQuery(QStringLiteral("https://music.163.com/api/search/get"), urlQuery), QStringLiteral("netease"), QStringLiteral("netease-search"));
 }
 
 void LyricsMprisApp::startQq() {
@@ -540,6 +563,7 @@ void LyricsMprisApp::copyCandidateMetadata(QNetworkReply *reply, const ProviderC
     reply->setProperty("candidateArtist", candidate.artist);
     reply->setProperty("candidateAlbum", candidate.album);
     reply->setProperty("candidateDurationMs", candidate.durationMs);
+    reply->setProperty("candidateMetadataTrusted", candidate.metadataTrusted);
 }
 
 ProviderCandidate LyricsMprisApp::candidateFromReply(QNetworkReply *reply, ProviderCandidate candidate) const {
@@ -547,10 +571,8 @@ ProviderCandidate LyricsMprisApp::candidateFromReply(QNetworkReply *reply, Provi
     if (candidate.artist.isEmpty()) candidate.artist = reply->property("candidateArtist").toString();
     if (candidate.album.isEmpty()) candidate.album = reply->property("candidateAlbum").toString();
     if (candidate.durationMs <= 0) candidate.durationMs = reply->property("candidateDurationMs").toInt();
-    if (candidate.title.isEmpty()) candidate.title = m_currentPlayer.title;
-    if (candidate.artist.isEmpty()) candidate.artist = m_currentPlayer.artist;
-    if (candidate.album.isEmpty()) candidate.album = m_currentPlayer.album;
-    if (candidate.durationMs <= 0) candidate.durationMs = int(m_currentPlayer.lengthMs);
+    if (reply->property("candidateMetadataTrusted").isValid())
+        candidate.metadataTrusted = reply->property("candidateMetadataTrusted").toBool();
     return candidate;
 }
 
@@ -575,20 +597,21 @@ void LyricsMprisApp::handleNetworkFinished() {
         } else if (stage == QLatin1String("lrcx-text")) {
             ProviderCandidate candidate;
             candidate.provider = provider;
-            candidate.title = m_currentPlayer.title;
-            candidate.artist = m_currentPlayer.artist;
-            candidate.album = m_currentPlayer.album;
-            candidate.durationMs = int(m_currentPlayer.lengthMs);
+            candidate.metadataTrusted = false;
             candidate.syncedLyrics = QString::fromUtf8(body);
             considerCandidate(candidate);
         } else if (stage == QLatin1String("netease-search")) {
             QList<ProviderCandidate> candidates = parseNeteaseSearchJson(body);
-            std::sort(candidates.begin(), candidates.end(), [this](const ProviderCandidate &left, const ProviderCandidate &right) {
-                return scoreCandidate(queryFor(m_currentPlayer), left) > scoreCandidate(queryFor(m_currentPlayer), right);
+            const TrackQuery trackQuery = queryFor(m_currentPlayer);
+            std::sort(candidates.begin(), candidates.end(), [&trackQuery](const ProviderCandidate &left, const ProviderCandidate &right) {
+                return scoreCandidate(trackQuery, left) > scoreCandidate(trackQuery, right);
             });
-            const int limit = qMin(3, candidates.size());
-            for (int index = 0; index < limit; ++index) {
+            int requested = 0;
+            for (int index = 0; index < candidates.size() && requested < kDownloadCandidateLimit; ++index) {
                 const ProviderCandidate &candidate = candidates.at(index);
+                const CandidateEvaluation evaluation = evaluateCandidate(trackQuery, candidate);
+                debugCandidate(candidate, evaluation, evaluation.accepted ? QStringLiteral("download") : QStringLiteral("skip"));
+                if (!evaluation.accepted) continue;
                 QUrlQuery query;
                 query.addQueryItem(QStringLiteral("os"), QStringLiteral("pc"));
                 query.addQueryItem(QStringLiteral("id"), candidate.syncedLyrics);
@@ -596,34 +619,44 @@ void LyricsMprisApp::handleNetworkFinished() {
                 query.addQueryItem(QStringLiteral("tv"), QStringLiteral("-1"));
                 QNetworkReply *next = get(withQuery(QStringLiteral("https://music.163.com/api/song/lyric"), query), provider, QStringLiteral("netease-lyric"));
                 copyCandidateMetadata(next, candidate);
+                requested++;
             }
         } else if (stage == QLatin1String("netease-lyric")) {
             considerCandidate(candidateFromReply(reply, parseNeteaseLyricJson(body)));
         } else if (stage == QLatin1String("qq-search")) {
             QList<ProviderCandidate> candidates = parseQqSearchJson(body);
-            std::sort(candidates.begin(), candidates.end(), [this](const ProviderCandidate &left, const ProviderCandidate &right) {
-                return scoreCandidate(queryFor(m_currentPlayer), left) > scoreCandidate(queryFor(m_currentPlayer), right);
+            const TrackQuery trackQuery = queryFor(m_currentPlayer);
+            std::sort(candidates.begin(), candidates.end(), [&trackQuery](const ProviderCandidate &left, const ProviderCandidate &right) {
+                return scoreCandidate(trackQuery, left) > scoreCandidate(trackQuery, right);
             });
-            const int limit = qMin(3, candidates.size());
-            for (int index = 0; index < limit; ++index) {
+            int requested = 0;
+            for (int index = 0; index < candidates.size() && requested < kDownloadCandidateLimit; ++index) {
                 const ProviderCandidate &candidate = candidates.at(index);
+                const CandidateEvaluation evaluation = evaluateCandidate(trackQuery, candidate);
+                debugCandidate(candidate, evaluation, evaluation.accepted ? QStringLiteral("download") : QStringLiteral("skip"));
+                if (!evaluation.accepted) continue;
                 QUrlQuery query;
                 query.addQueryItem(QStringLiteral("songmid"), candidate.syncedLyrics);
                 query.addQueryItem(QStringLiteral("format"), QStringLiteral("json"));
                 query.addQueryItem(QStringLiteral("nobase64"), QStringLiteral("1"));
                 QNetworkReply *next = get(withQuery(QStringLiteral("https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg"), query), provider, QStringLiteral("qq-lyric"));
                 copyCandidateMetadata(next, candidate);
+                requested++;
             }
         } else if (stage == QLatin1String("qq-lyric")) {
             considerCandidate(candidateFromReply(reply, parseQqLyricJson(body)));
         } else if (stage == QLatin1String("kugou-song-search")) {
             QList<ProviderCandidate> candidates = parseKugouSongSearchJson(body);
-            std::sort(candidates.begin(), candidates.end(), [this](const ProviderCandidate &left, const ProviderCandidate &right) {
-                return scoreCandidate(queryFor(m_currentPlayer), left) > scoreCandidate(queryFor(m_currentPlayer), right);
+            const TrackQuery trackQuery = queryFor(m_currentPlayer);
+            std::sort(candidates.begin(), candidates.end(), [&trackQuery](const ProviderCandidate &left, const ProviderCandidate &right) {
+                return scoreCandidate(trackQuery, left) > scoreCandidate(trackQuery, right);
             });
-            const int limit = qMin(3, candidates.size());
-            for (int index = 0; index < limit; ++index) {
+            int requested = 0;
+            for (int index = 0; index < candidates.size() && requested < kDownloadCandidateLimit; ++index) {
                 const ProviderCandidate &candidate = candidates.at(index);
+                const CandidateEvaluation evaluation = evaluateCandidate(trackQuery, candidate);
+                debugCandidate(candidate, evaluation, evaluation.accepted ? QStringLiteral("download") : QStringLiteral("skip"));
+                if (!evaluation.accepted) continue;
                 QUrlQuery query;
                 query.addQueryItem(QStringLiteral("ver"), QStringLiteral("1"));
                 query.addQueryItem(QStringLiteral("man"), QStringLiteral("yes"));
@@ -633,6 +666,7 @@ void LyricsMprisApp::handleNetworkFinished() {
                 query.addQueryItem(QStringLiteral("hash"), candidate.syncedLyrics);
                 QNetworkReply *next = get(withQuery(QStringLiteral("https://lyrics.kugou.com/search"), query), provider, QStringLiteral("kugou-lyric-search"));
                 copyCandidateMetadata(next, candidate);
+                requested++;
             }
         } else if (stage == QLatin1String("kugou-lyric-search")) {
             const QList<QJsonObject> candidates = parseKugouLyricSearchJson(body);
@@ -667,17 +701,33 @@ void LyricsMprisApp::handleNetworkFinished() {
 }
 
 void LyricsMprisApp::considerCandidate(ProviderCandidate candidate) {
-    const int score = scoreCandidate(queryFor(m_currentPlayer), candidate);
+    if (m_currentDocument.hasSyncedLines()) return;
+
+    const CandidateEvaluation evaluation = evaluateCandidate(queryFor(m_currentPlayer), candidate);
+    debugCandidate(candidate, evaluation, evaluation.accepted ? QStringLiteral("candidate") : QStringLiteral("reject"));
+    if (!evaluation.accepted) return;
+
     LyricDocument document = documentFromCandidate(candidate);
     if (document.isEmpty()) return;
 
-    if (document.hasSyncedLines() && score >= kAcceptScore) {
-        acceptDocument(std::move(document), QStringLiteral("synced"), true);
+    if (document.hasSyncedLines()) {
+        if (evaluation.highConfidence) {
+            acceptDocument(std::move(document), QStringLiteral("synced"), true);
+            return;
+        }
+        rememberSyncedCandidate(std::move(document), evaluation.score);
         return;
     }
 
-    if (document.hasPlainLines() && score >= kPlainScore)
-        rememberPlainCandidate(std::move(candidate), score);
+    if (document.hasPlainLines())
+        rememberPlainCandidate(std::move(candidate), evaluation.score);
+}
+
+void LyricsMprisApp::rememberSyncedCandidate(LyricDocument document, int score) {
+    if (score <= m_bestSyncedScore) return;
+    m_bestSyncedScore = score;
+    m_bestSyncedDocument.clearAndFree();
+    m_bestSyncedDocument = std::move(document);
 }
 
 void LyricsMprisApp::rememberPlainCandidate(ProviderCandidate candidate, int score) {
@@ -697,11 +747,17 @@ void LyricsMprisApp::acceptDocument(LyricDocument document, const QString &statu
         abortNetwork();
         m_fallbackTimer.stop();
     }
+    maybeQuitLookup();
 }
 
 void LyricsMprisApp::maybeFinishSearch() {
     if (m_pendingReplies > 0 || !m_fallbackStarted || m_currentTrackKey.isEmpty()) return;
     if (m_currentDocument.hasSyncedLines()) return;
+
+    if (m_bestSyncedDocument.hasSyncedLines()) {
+        acceptDocument(std::move(m_bestSyncedDocument), QStringLiteral("synced"), true);
+        return;
+    }
 
     if (!m_bestPlainCandidate.plainLyrics.isEmpty()) {
         LyricDocument plain = documentFromCandidate(m_bestPlainCandidate);
@@ -714,6 +770,7 @@ void LyricsMprisApp::maybeFinishSearch() {
     if (!m_hasAcceptedDocument) {
         emitLine(QString(), false);
         emitStatus(QStringLiteral("not_found"));
+        maybeQuitLookup();
     }
 }
 
@@ -755,6 +812,7 @@ void LyricsMprisApp::clearCurrentTrack() {
     m_positionTimer.stop();
     abortNetwork();
     releaseCurrentDocument();
+    m_bestSyncedDocument.clearAndFree();
     m_currentTrackKey.clear();
     m_currentTrackKey.squeeze();
     m_currentPlayer = PlayerInfo();
@@ -763,6 +821,7 @@ void LyricsMprisApp::clearCurrentTrack() {
     m_startedProviders.clear();
     m_fallbackStarted = false;
     m_hasAcceptedDocument = false;
+    m_bestSyncedScore = 0;
     m_bestPlainScore = 0;
     m_bestPlainCandidate = ProviderCandidate();
     emitLine(QString(), false);
@@ -782,6 +841,33 @@ void LyricsMprisApp::abortNetwork() {
     }
     m_replies.clear();
     m_pendingReplies = 0;
+}
+
+void LyricsMprisApp::maybeQuitLookup() {
+    if (m_options.lookupMode)
+        QTimer::singleShot(0, QCoreApplication::instance(), &QCoreApplication::quit);
+}
+
+void LyricsMprisApp::debugCandidate(const ProviderCandidate &candidate, const CandidateEvaluation &evaluation, const QString &action) const {
+    if (!lyricsDebugEnabled()) return;
+
+    QTextStream stream(stderr);
+    stream << "[LyricsMatch] " << action
+           << " provider=" << candidate.provider
+           << " title=\"" << candidate.title << "\""
+           << " artist=\"" << candidate.artist << "\""
+           << " album=\"" << candidate.album << "\""
+           << " durationMs=" << candidate.durationMs
+           << " trusted=" << (candidate.metadataTrusted ? "true" : "false")
+           << " score=" << evaluation.score
+           << " accepted=" << (evaluation.accepted ? "true" : "false")
+           << " high=" << (evaluation.highConfidence ? "true" : "false")
+           << " reason=" << evaluation.reason;
+    if (!evaluation.lyricMetadata.isEmpty()) {
+        stream << " lrcTitle=\"" << evaluation.lyricMetadata.title << "\""
+               << " lrcArtist=\"" << evaluation.lyricMetadata.artist << "\"";
+    }
+    stream << Qt::endl;
 }
 
 bool LyricsMprisApp::serviceBlocked(const QString &service) const {

--- a/lyricsmpris/LyricsMprisApp.h
+++ b/lyricsmpris/LyricsMprisApp.h
@@ -16,7 +16,12 @@ namespace lyricsmpris {
 
 struct AppOptions {
     bool pipe = true;
+    bool lookupMode = false;
     QString preferredService;
+    QString lookupTitle;
+    QString lookupArtist;
+    QString lookupAlbum;
+    int lookupDurationMs = 0;
     QStringList providers;
     QSet<QString> blockedServices;
 };
@@ -59,6 +64,7 @@ private:
     void clearCurrentTrack();
     void releaseCurrentDocument();
     void abortNetwork();
+    void startLookup();
     void chooseActivePlayer();
     void updatePlayer(const QString &service);
     void startTrack(const PlayerInfo &player);
@@ -80,7 +86,10 @@ private:
     void considerCandidate(ProviderCandidate candidate);
     void acceptDocument(LyricDocument document, const QString &status, bool finalSynced);
     void maybeFinishSearch();
+    void rememberSyncedCandidate(LyricDocument document, int score);
     void rememberPlainCandidate(ProviderCandidate candidate, int score);
+    void maybeQuitLookup();
+    void debugCandidate(const ProviderCandidate &candidate, const CandidateEvaluation &evaluation, const QString &action) const;
     bool serviceBlocked(const QString &service) const;
     static QVariant unwrapDbusVariant(const QVariant &value);
     static QString variantToString(const QVariant &value);
@@ -97,7 +106,9 @@ private:
     QString m_currentTrackKey;
     PlayerInfo m_currentPlayer;
     LyricDocument m_currentDocument;
+    LyricDocument m_bestSyncedDocument;
     ProviderCandidate m_bestPlainCandidate;
+    int m_bestSyncedScore = 0;
     int m_bestPlainScore = 0;
     int m_generation = 0;
     int m_pendingReplies = 0;

--- a/lyricsmpris/main.cpp
+++ b/lyricsmpris/main.cpp
@@ -39,6 +39,10 @@ int main(int argc, char *argv[]) {
     const QCommandLineOption noKaraokeOption(QStringLiteral("no-karaoke"), QStringLiteral("Accepted for compatibility; per-word karaoke rendering is not used in pipe mode"));
     const QCommandLineOption visibleLinesOption(QStringLiteral("visible-lines"), QStringLiteral("Accepted for compatibility; pipe mode emits one current line"), QStringLiteral("COUNT"));
     const QCommandLineOption listProvidersOption(QStringLiteral("list-providers"), QStringLiteral("Print supported provider names and exit"));
+    const QCommandLineOption lookupTitleOption(QStringLiteral("lookup-title"), QStringLiteral("Run one lyrics lookup without MPRIS"), QStringLiteral("TITLE"));
+    const QCommandLineOption lookupArtistOption(QStringLiteral("lookup-artist"), QStringLiteral("Artist for --lookup-title"), QStringLiteral("ARTIST"));
+    const QCommandLineOption lookupAlbumOption(QStringLiteral("lookup-album"), QStringLiteral("Album for --lookup-title"), QStringLiteral("ALBUM"));
+    const QCommandLineOption lookupDurationOption(QStringLiteral("lookup-duration-ms"), QStringLiteral("Duration in milliseconds for --lookup-title"), QStringLiteral("MS"));
 
     parser.addOption(pipeOption);
     parser.addOption(blockOption);
@@ -47,6 +51,10 @@ int main(int argc, char *argv[]) {
     parser.addOption(noKaraokeOption);
     parser.addOption(visibleLinesOption);
     parser.addOption(listProvidersOption);
+    parser.addOption(lookupTitleOption);
+    parser.addOption(lookupArtistOption);
+    parser.addOption(lookupAlbumOption);
+    parser.addOption(lookupDurationOption);
     parser.process(app);
 
     if (parser.isSet(listProvidersOption)) {
@@ -56,6 +64,11 @@ int main(int argc, char *argv[]) {
 
     AppOptions options;
     options.pipe = true;
+    options.lookupMode = parser.isSet(lookupTitleOption);
+    options.lookupTitle = parser.value(lookupTitleOption);
+    options.lookupArtist = parser.value(lookupArtistOption);
+    options.lookupAlbum = parser.value(lookupAlbumOption);
+    options.lookupDurationMs = parser.value(lookupDurationOption).toInt();
     options.providers = parser.isSet(providersOption)
         ? splitCommaList(parser.value(providersOption))
         : QStringList();

--- a/tests/lyricsmpris_core_tests.cpp
+++ b/tests/lyricsmpris_core_tests.cpp
@@ -11,8 +11,15 @@ private slots:
     void parsesSyncedLrc();
     void parsesMultiTimestampLines();
     void keepsPlainLyricsFallback();
+    void filtersPlaceholderLyrics();
     void normalizesNoisyTitles();
     void scoresLikelyMatches();
+    void acceptsChineseAndAliasMatches();
+    void acceptsListedCollaborators();
+    void rejectsWrongVersionsAndDurations();
+    void rejectsConflictingLyricMetadata();
+    void requiresTrustedOrLyricMetadata();
+    void parsesNeteaseSearchShapes();
     void parsesProviderFixtures();
     void releasesDocumentStorage();
 };
@@ -45,6 +52,11 @@ void LyricsMprisCoreTests::keepsPlainLyricsFallback() {
     QCOMPARE(selectLineAt(document, 0), QString("Line one"));
 }
 
+void LyricsMprisCoreTests::filtersPlaceholderLyrics() {
+    QVERIFY(parseLyrics("[00:01.00]暂无歌词\n").isEmpty());
+    QVERIFY(parseLyrics("纯音乐，请欣赏\n").isEmpty());
+}
+
 void LyricsMprisCoreTests::normalizesNoisyTitles() {
     QCOMPARE(normalizedTitle("Song Title (feat. Someone) - Remastered 2011"), QString("song title"));
     QCOMPARE(normalizedTitle("HELLO!!! [Official Lyric Video]"), QString("hello"));
@@ -72,6 +84,152 @@ void LyricsMprisCoreTests::scoresLikelyMatches() {
 
     QVERIFY(scoreCandidate(query, good) >= 100);
     QVERIFY(scoreCandidate(query, bad) < scoreCandidate(query, good));
+}
+
+void LyricsMprisCoreTests::acceptsChineseAndAliasMatches() {
+    TrackQuery chinese;
+    chinese.title = "告白气球";
+    chinese.artist = "周杰伦";
+    chinese.durationMs = 215000;
+
+    ProviderCandidate candidate;
+    candidate.title = "告白氣球";
+    candidate.artist = "周傑倫 (Jay Chou)";
+    candidate.durationMs = 209000;
+    candidate.syncedLyrics = "[ti:告白氣球]\n[ar:周傑倫]\n[00:01.00]塞納河畔";
+
+    const CandidateEvaluation chineseEvaluation = evaluateCandidate(chinese, candidate);
+    QVERIFY2(chineseEvaluation.accepted, qPrintable(chineseEvaluation.reason));
+    QVERIFY(chineseEvaluation.highConfidence);
+
+    TrackQuery englishAlias;
+    englishAlias.title = "光年之外";
+    englishAlias.artist = "G.E.M. 邓紫棋";
+    englishAlias.durationMs = 235000;
+
+    ProviderCandidate aliasCandidate;
+    aliasCandidate.title = "光年之外";
+    aliasCandidate.artist = "G E M 鄧紫棋";
+    aliasCandidate.durationMs = 235500;
+    aliasCandidate.syncedLyrics = "[ti:光年之外]\n[ar:G.E.M. 鄧紫棋]\n[00:01.00]感受停在我发端的指尖";
+
+    const CandidateEvaluation aliasEvaluation = evaluateCandidate(englishAlias, aliasCandidate);
+    QVERIFY2(aliasEvaluation.accepted, qPrintable(aliasEvaluation.reason));
+    QVERIFY(aliasEvaluation.highConfidence);
+}
+
+void LyricsMprisCoreTests::acceptsListedCollaborators() {
+    TrackQuery query;
+    query.title = "你知道你比晚霞好看吗";
+    query.artist = "BK";
+    query.durationMs = 179000;
+
+    ProviderCandidate collaboration;
+    collaboration.title = "你知道你比晚霞好看嗎 - Better than Sunset";
+    collaboration.artist = "Tr33, BK, & Seluu";
+    collaboration.durationMs = 179000;
+    collaboration.syncedLyrics = "[00:01.00]Hey";
+
+    const CandidateEvaluation collaborationEvaluation = evaluateCandidate(query, collaboration);
+    QVERIFY2(collaborationEvaluation.accepted, qPrintable(collaborationEvaluation.reason));
+
+    ProviderCandidate unrelated = collaboration;
+    unrelated.title = "Grow With The Flow";
+    unrelated.artist = "BILLKIN";
+    QCOMPARE(evaluateCandidate(query, unrelated).reason, QString("title_mismatch"));
+}
+
+void LyricsMprisCoreTests::rejectsWrongVersionsAndDurations() {
+    TrackQuery query;
+    query.title = "告白气球";
+    query.artist = "周杰伦";
+    query.durationMs = 215000;
+
+    ProviderCandidate shortClip;
+    shortClip.title = "告白气球";
+    shortClip.artist = "周杰伦";
+    shortClip.durationMs = 60000;
+    shortClip.syncedLyrics = "[00:01.00]Wrong short clip";
+    QCOMPARE(evaluateCandidate(query, shortClip).reason, QString("duration_mismatch"));
+
+    TrackQuery shortQuery = query;
+    shortQuery.durationMs = 60000;
+    ProviderCandidate missingDuration = shortClip;
+    missingDuration.durationMs = 0;
+    QCOMPARE(evaluateCandidate(shortQuery, missingDuration).reason, QString("missing_candidate_duration"));
+
+    ProviderCandidate cover = shortClip;
+    cover.title = "告白气球 (Cover)";
+    cover.artist = "Xai小爱";
+    cover.durationMs = 215000;
+    QCOMPARE(evaluateCandidate(query, cover).reason, QString("version_mismatch"));
+
+    ProviderCandidate piano = shortClip;
+    piano.title = "告白气球 (钢琴版) [原唱: 周杰伦]";
+    piano.durationMs = 215000;
+    QCOMPARE(evaluateCandidate(query, piano).reason, QString("version_mismatch"));
+
+    ProviderCandidate live = shortClip;
+    live.title = "告白气球 (Live)";
+    live.durationMs = 264000;
+    QCOMPARE(evaluateCandidate(query, live).reason, QString("version_mismatch"));
+}
+
+void LyricsMprisCoreTests::rejectsConflictingLyricMetadata() {
+    TrackQuery query;
+    query.title = "Song Title";
+    query.artist = "Main Artist";
+    query.durationMs = 180000;
+
+    ProviderCandidate wrongTitle;
+    wrongTitle.title = "Song Title";
+    wrongTitle.artist = "Main Artist";
+    wrongTitle.durationMs = 180000;
+    wrongTitle.syncedLyrics = "[ti:Different Song]\n[ar:Main Artist]\n[00:01.00]Hello";
+    QCOMPARE(evaluateCandidate(query, wrongTitle).reason, QString("lyric_title_mismatch"));
+
+    ProviderCandidate wrongArtist = wrongTitle;
+    wrongArtist.syncedLyrics = "[ti:Song Title]\n[ar:Other Artist]\n[00:01.00]Hello";
+    QCOMPARE(evaluateCandidate(query, wrongArtist).reason, QString("lyric_artist_mismatch"));
+}
+
+void LyricsMprisCoreTests::requiresTrustedOrLyricMetadata() {
+    TrackQuery query;
+    query.title = "Song Title";
+    query.artist = "Main Artist";
+    query.durationMs = 180000;
+
+    ProviderCandidate untrusted;
+    untrusted.metadataTrusted = false;
+    untrusted.syncedLyrics = "[00:01.00]Hello";
+    QCOMPARE(evaluateCandidate(query, untrusted).reason, QString("untrusted_metadata"));
+
+    untrusted.syncedLyrics = "[ti:Song Title]\n[ar:Main Artist]\n[00:01.00]Hello";
+    const CandidateEvaluation evaluation = evaluateCandidate(query, untrusted);
+    QVERIFY2(evaluation.accepted, qPrintable(evaluation.reason));
+}
+
+void LyricsMprisCoreTests::parsesNeteaseSearchShapes() {
+    const QByteArray modern = R"({
+        "result": {
+            "songs": [{
+                "name": "告白气球",
+                "id": 12345,
+                "ar": [{"name": "周杰伦"}],
+                "al": {"name": "周杰伦的床边故事"},
+                "dt": 215000
+            }]
+        }
+    })";
+    QList<ProviderCandidate> modernCandidates = parseNeteaseSearchJson(modern);
+    QCOMPARE(modernCandidates.size(), 1);
+    QCOMPARE(modernCandidates.first().artist, QString("周杰伦"));
+    QCOMPARE(modernCandidates.first().album, QString("周杰伦的床边故事"));
+    QCOMPARE(modernCandidates.first().durationMs, 215000);
+    QCOMPARE(modernCandidates.first().syncedLyrics, QString("12345"));
+
+    const QByteArray encrypted = R"({"result":"35b1748964af8a7c","code":200})";
+    QVERIFY(parseNeteaseSearchJson(encrypted).isEmpty());
 }
 
 void LyricsMprisCoreTests::parsesProviderFixtures() {


### PR DESCRIPTION
## What changed

- Improve lyrics candidate scoring with title/artist/album similarity, CJK variant normalization, version flags, and duration checks.
- Reject placeholder lyrics and mismatched lyric metadata before accepting a candidate.
- Add a one-shot lookup mode for `lyricsmpris` using `--lookup-title`, `--lookup-artist`, `--lookup-album`, and `--lookup-duration-ms`.
- Keep the local `lyricsmpris_core_tests.cpp` test coverage and expand it for matching, metadata, placeholder filtering, and NetEase search JSON shapes.
- Bump package metadata to `1.0.6` so AUR can point at a stable tag containing these changes.

## Notes

This branch was merged with the latest `main` and intentionally keeps `tests/lyricsmpris_core_tests.cpp`, even though `main` had deleted it in `19d51b9`, because the local folder still had expanded tests for these changes.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `makepkg --printsrcinfo` shows `pkgver = 1.0.6` and the `1.0.6` tag source URL.