### PR TITLE
[codex] Restore Musixmatch reply metadata

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: whysooraj <whysooraj.official@gmail.com>
 pkgname=tide-island
-_srcdir=Tide-island-1.0.6
-pkgver=1.0.6
+_srcdir=Tide-island-1.0.7
+pkgver=1.0.7
 pkgrel=1
 pkgdesc="A dynamic island for Hyprland using Quickshell"
 arch=('x86_64')

--- a/lyricsmpris/LyricsMprisApp.cpp
+++ b/lyricsmpris/LyricsMprisApp.cpp
@@ -526,14 +526,24 @@ void LyricsMprisApp::startMusixmatch() {
     if (apiKey.isEmpty()) return;
 
     const TrackQuery query = queryFor(m_currentPlayer);
+    ProviderCandidate requestMetadata;
+    requestMetadata.provider = QStringLiteral("musixmatch");
+    requestMetadata.title = query.title;
+    requestMetadata.artist = query.artist;
+    requestMetadata.album = query.album;
+    requestMetadata.durationMs = query.durationMs;
+    requestMetadata.metadataTrusted = true;
+
     QUrlQuery subtitleQuery;
     subtitleQuery.addQueryItem(QStringLiteral("q_track"), query.title);
     subtitleQuery.addQueryItem(QStringLiteral("q_artist"), query.artist);
     subtitleQuery.addQueryItem(QStringLiteral("apikey"), apiKey);
-    get(withQuery(QStringLiteral("https://api.musixmatch.com/ws/1.1/matcher.subtitle.get"), subtitleQuery), QStringLiteral("musixmatch"), QStringLiteral("musixmatch-subtitle"));
+    QNetworkReply *subtitleReply = get(withQuery(QStringLiteral("https://api.musixmatch.com/ws/1.1/matcher.subtitle.get"), subtitleQuery), QStringLiteral("musixmatch"), QStringLiteral("musixmatch-subtitle"));
+    copyCandidateMetadata(subtitleReply, requestMetadata);
 
     QUrlQuery lyricsQuery = subtitleQuery;
-    get(withQuery(QStringLiteral("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get"), lyricsQuery), QStringLiteral("musixmatch"), QStringLiteral("musixmatch-lyrics"));
+    QNetworkReply *lyricsReply = get(withQuery(QStringLiteral("https://api.musixmatch.com/ws/1.1/matcher.lyrics.get"), lyricsQuery), QStringLiteral("musixmatch"), QStringLiteral("musixmatch-lyrics"));
+    copyCandidateMetadata(lyricsReply, requestMetadata);
 }
 
 QNetworkReply *LyricsMprisApp::get(const QUrl &url, const QString &provider, const QString &stage) {

--- a/tests/lyricsmpris_core_tests.cpp
+++ b/tests/lyricsmpris_core_tests.cpp
@@ -19,6 +19,7 @@ private slots:
     void rejectsWrongVersionsAndDurations();
     void rejectsConflictingLyricMetadata();
     void requiresTrustedOrLyricMetadata();
+    void acceptsMusixmatchWithRequestMetadata();
     void parsesNeteaseSearchShapes();
     void parsesProviderFixtures();
     void releasesDocumentStorage();
@@ -207,6 +208,39 @@ void LyricsMprisCoreTests::requiresTrustedOrLyricMetadata() {
     untrusted.syncedLyrics = "[ti:Song Title]\n[ar:Main Artist]\n[00:01.00]Hello";
     const CandidateEvaluation evaluation = evaluateCandidate(query, untrusted);
     QVERIFY2(evaluation.accepted, qPrintable(evaluation.reason));
+}
+
+void LyricsMprisCoreTests::acceptsMusixmatchWithRequestMetadata() {
+    TrackQuery query;
+    query.title = "Song Title";
+    query.artist = "Main Artist";
+    query.album = "Album";
+    query.durationMs = 180000;
+
+    const QByteArray payload = R"({
+        "message": {
+            "body": {
+                "subtitle": {
+                    "subtitle_body": "[00:01.00]Hello"
+                }
+            }
+        }
+    })";
+
+    QList<ProviderCandidate> candidates = parseMusixmatchJson(payload, QStringLiteral("musixmatch"));
+    QCOMPARE(candidates.size(), 1);
+    QCOMPARE(evaluateCandidate(query, candidates.first()).reason, QString("untrusted_metadata"));
+
+    ProviderCandidate candidate = candidates.first();
+    candidate.title = query.title;
+    candidate.artist = query.artist;
+    candidate.album = query.album;
+    candidate.durationMs = query.durationMs;
+    candidate.metadataTrusted = true;
+
+    const CandidateEvaluation evaluation = evaluateCandidate(query, candidate);
+    QVERIFY2(evaluation.accepted, qPrintable(evaluation.reason));
+    QVERIFY(documentFromCandidate(candidate).hasSyncedLines());
 }
 
 void LyricsMprisCoreTests::parsesNeteaseSearchShapes() {


### PR DESCRIPTION
## What changed

- Attach the current track metadata to Musixmatch subtitle and lyrics matcher replies with `copyCandidateMetadata()`.
- Keep Musixmatch matcher results eligible for the new candidate evaluator instead of rejecting them as `untrusted_metadata`.
- Restore `tests/lyricsmpris_core_tests.cpp` because latest `main` deleted it while `CMakeLists.txt` still builds `lyricsmpris_tests` from that file.
- Add a regression test showing raw Musixmatch payloads are untrusted by themselves, but are accepted once request metadata is restored.
- Bump package metadata to `1.0.7` so AUR can point at a stable tag with this fix.

## Why

Codex review on #12 was correct: after `parseMusixmatchJson()` started marking Musixmatch payloads as untrusted, the requests created in `startMusixmatch()` no longer supplied title/artist/duration metadata. Most Musixmatch responses do not include `[ti:]` or `[ar:]` LRC tags, so they were rejected before they could be used.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `makepkg --printsrcinfo` shows `pkgver = 1.0.7` and the `1.0.7` tag source URL.