### PR TITLE
Add Debian/Ubuntu integration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,36 @@ cd Tide-island
 ./scripts/install-debian-ubuntu.sh
 ```
 
+Debian / Ubuntu installer also applies common desktop integration fixes by
+default:
+
+- disables common Waybar systemd startup paths and comments direct
+  `exec-once = waybar` entries in `~/.config/hypr`
+- mutes SwayNC notification popups so Tide Island does not show duplicate
+  notifications
+- adds a `Ctrl + Super + Alt + B` Hyprland binding to toggle the Tide Island
+  user service
+- sets a user service drop-in with `TIDE_ISLAND_SKIP_SETUP=1` so the setup
+  wizard does not keep reopening after installation
+
+Backups are written next to modified user config files with a
+`.tide-island.bak.<timestamp>` suffix.
+
+If you manage those pieces yourself, disable the integration step:
+
+```bash
+./scripts/install-debian-ubuntu.sh --no-desktop-integration
+```
+
+Or disable only one part:
+
+```bash
+./scripts/install-debian-ubuntu.sh --no-disable-waybar
+./scripts/install-debian-ubuntu.sh --no-mute-swaync
+./scripts/install-debian-ubuntu.sh --no-toggle-bind
+./scripts/install-debian-ubuntu.sh --keep-setup-wizard
+```
+
 <br>
 
 ## Starting Tide Island

--- a/scripts/install-debian-ubuntu.sh
+++ b/scripts/install-debian-ubuntu.sh
@@ -6,6 +6,11 @@ PREFIX="/usr"
 SKIP_QUICKSHELL=0
 FORCE_BUILD_QUICKSHELL=0
 ENABLE_SERVICE=1
+APPLY_DESKTOP_INTEGRATION=1
+DISABLE_WAYBAR=1
+MUTE_SWAYNC=1
+INSTALL_TOGGLE_BIND=1
+SKIP_SETUP_WIZARD=1
 
 REQUIRED_PACKAGES=(
   git
@@ -37,6 +42,7 @@ REQUIRED_PACKAGES=(
   pulseaudio-utils
   brightnessctl
   dbus-bin
+  python3
   upower
   bluez
 )
@@ -57,6 +63,11 @@ Options:
   --skip-quickshell        Assume Quickshell is already installed.
   --force-build-quickshell Build Quickshell even if quickshell is already in PATH.
   --no-enable-service      Install only; do not enable or start the systemd user service.
+  --no-desktop-integration Do not change Waybar, SwayNC, Hyprland keybinds, or setup wizard behavior.
+  --no-disable-waybar      Do not disable Waybar services or Hyprland exec-once entries.
+  --no-mute-swaync         Do not mute SwayNC notification popups.
+  --no-toggle-bind         Do not install the Ctrl+Super+Alt+B Tide Island toggle keybind.
+  --keep-setup-wizard      Do not set TIDE_ISLAND_SKIP_SETUP=1 in the user service override.
   --prefix DIR             Install prefix. Currently only /usr is supported.
   -h, --help               Show this help message.
 EOF
@@ -86,6 +97,21 @@ parse_args() {
         ;;
       --no-enable-service)
         ENABLE_SERVICE=0
+        ;;
+      --no-desktop-integration)
+        APPLY_DESKTOP_INTEGRATION=0
+        ;;
+      --no-disable-waybar)
+        DISABLE_WAYBAR=0
+        ;;
+      --no-mute-swaync)
+        MUTE_SWAYNC=0
+        ;;
+      --no-toggle-bind)
+        INSTALL_TOGGLE_BIND=0
+        ;;
+      --keep-setup-wizard)
+        SKIP_SETUP_WIZARD=0
         ;;
       --prefix)
         shift
@@ -259,6 +285,230 @@ build_tide_island() {
   sudo cmake --install "$root/build-debian-ubuntu"
 }
 
+timestamp() {
+  date +%Y%m%d-%H%M%S
+}
+
+backup_file() {
+  local path="$1"
+  [[ -f "$path" ]] || return 0
+  cp -p "$path" "$path.tide-island.bak.$(timestamp)"
+}
+
+systemctl_user_exists() {
+  systemctl --user list-unit-files "$1" --no-legend 2>/dev/null | grep -q .
+}
+
+disable_waybar_conflicts() {
+  ((APPLY_DESKTOP_INTEGRATION && DISABLE_WAYBAR)) || return 0
+
+  log "Disabling Waybar conflicts when present"
+
+  if systemctl_user_exists waybar.service; then
+    systemctl --user disable --now waybar.service >/dev/null 2>&1 || warn "could not disable user waybar.service"
+  fi
+
+  if systemctl_user_exists waybar-autohide.service; then
+    systemctl --user disable --now waybar-autohide.service >/dev/null 2>&1 || warn "could not disable user waybar-autohide.service"
+  fi
+
+  sudo systemctl --global disable waybar.service >/dev/null 2>&1 || true
+  sudo systemctl --global disable waybar-autohide.service >/dev/null 2>&1 || true
+
+  local hypr_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
+  [[ -d "$hypr_dir" ]] || return 0
+
+  python3 - "$hypr_dir" <<'PY'
+import pathlib
+import re
+import shutil
+import sys
+import time
+
+root = pathlib.Path(sys.argv[1])
+pattern = re.compile(r'^(\s*)exec-once\s*=\s*waybar(?:\s.*)?$', re.IGNORECASE)
+
+for path in root.rglob("*.conf"):
+    try:
+        text = path.read_text()
+    except UnicodeDecodeError:
+        continue
+
+    changed = False
+    out = []
+    for line in text.splitlines(keepends=True):
+        line_body = line.rstrip("\n")
+        newline = "\n" if line.endswith("\n") else ""
+        if not line_body.lstrip().startswith("#") and pattern.match(line_body):
+            out.append("# Tide Island replaces Waybar as the top bar." + newline)
+            out.append("# " + line_body + newline)
+            changed = True
+        else:
+            out.append(line)
+
+    if changed:
+        backup = path.with_name(path.name + ".tide-island.bak." + time.strftime("%Y%m%d-%H%M%S"))
+        shutil.copy2(path, backup)
+        path.write_text("".join(out))
+        print(f"commented Waybar exec-once in {path}")
+PY
+}
+
+mute_swaync_popups() {
+  ((APPLY_DESKTOP_INTEGRATION && MUTE_SWAYNC)) || return 0
+
+  local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/swaync"
+  local config="$config_dir/config.json"
+  [[ -f "$config" ]] || {
+    warn "SwayNC config was not found; skipping SwayNC popup mute"
+    return 0
+  }
+
+  log "Muting SwayNC notification popups to avoid duplicate Tide Island notifications"
+  backup_file "$config"
+
+  if ! python3 - "$config" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open() as f:
+    data = json.load(f)
+
+visibility = data.setdefault("notification-visibility", {})
+visibility["tide-island-handles-popups"] = {
+    "state": "muted",
+    "app-name": ".*",
+}
+
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+  then
+    warn "could not update SwayNC config; leaving it unchanged"
+    return 0
+  fi
+
+  systemctl --user restart swaync.service >/dev/null 2>&1 || true
+}
+
+install_toggle_keybind() {
+  ((APPLY_DESKTOP_INTEGRATION && INSTALL_TOGGLE_BIND)) || return 0
+
+  local hypr_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
+  [[ -d "$hypr_dir" ]] || {
+    warn "Hyprland config directory was not found; skipping Tide Island toggle keybind"
+    return 0
+  }
+
+  log "Installing Ctrl+Super+Alt+B Tide Island toggle keybind"
+
+  local scripts_dir="$hypr_dir/scripts"
+  local script="$scripts_dir/TideIslandToggle.sh"
+  mkdir -p "$scripts_dir"
+  cat >"$script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if systemctl --user is-active --quiet tide-island.service; then
+  systemctl --user stop tide-island.service
+else
+  systemctl --user start tide-island.service
+fi
+EOF
+  chmod +x "$script"
+
+  local keybind_file="$hypr_dir/configs/Keybinds.conf"
+  [[ -f "$keybind_file" ]] || keybind_file="$hypr_dir/hyprland.conf"
+  backup_file "$keybind_file"
+
+  python3 - "$keybind_file" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text() if path.exists() else ""
+
+variables = {}
+for line in text.splitlines():
+    stripped = line.split("#", 1)[0].strip()
+    if stripped.startswith("$") and "=" in stripped:
+        name, value = stripped.split("=", 1)
+        variables[name.strip()] = value.strip()
+
+def resolves_to_super(token):
+    token = token.strip()
+    return token.upper() == "SUPER" or variables.get(token, "").upper() == "SUPER"
+
+def is_toggle_combo(line):
+    stripped = line.lstrip()
+    if stripped.startswith("#") or not stripped.lower().startswith("bind"):
+        return False
+    if "=" not in line:
+        return False
+    rhs = line.split("=", 1)[1]
+    parts = [part.strip() for part in rhs.split(",")]
+    if len(parts) < 2 or parts[1].upper() != "B":
+        return False
+    mods = re.split(r"[\s+|]+", parts[0])
+    upper_mods = {mod.upper() for mod in mods if mod}
+    has_super = any(resolves_to_super(mod) for mod in mods if mod)
+    return has_super and {"CTRL", "ALT"}.issubset(upper_mods)
+
+changed = False
+out = []
+for line in text.splitlines(keepends=True):
+    body = line.rstrip("\n")
+    newline = "\n" if line.endswith("\n") else ""
+    if is_toggle_combo(body) and "TideIslandToggle.sh" not in body:
+        out.append("# Replaced by Tide Island toggle.\n")
+        out.append("# " + body + newline)
+        changed = True
+    else:
+        out.append(line)
+
+if changed:
+    path.write_text("".join(out))
+PY
+
+  if ! grep -Eq 'TideIslandToggle\.sh|toggle tide island on/off' "$keybind_file"; then
+    cat >>"$keybind_file" <<EOF
+
+# Tide Island toggle
+bindd = \$mainMod CTRL ALT, B, toggle tide island on/off, exec, $script
+EOF
+  fi
+
+  hyprctl reload >/dev/null 2>&1 || true
+}
+
+configure_setup_wizard_behavior() {
+  ((APPLY_DESKTOP_INTEGRATION && SKIP_SETUP_WIZARD)) || return 0
+
+  log "Configuring service override to avoid repeatedly opening the setup wizard"
+  local override_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/tide-island.service.d"
+  mkdir -p "$override_dir"
+  cat >"$override_dir/10-skip-setup.conf" <<'EOF'
+[Service]
+Environment=TIDE_ISLAND_SKIP_SETUP=1
+EOF
+
+  systemctl --user daemon-reload >/dev/null 2>&1 || true
+}
+
+apply_desktop_integration() {
+  ((APPLY_DESKTOP_INTEGRATION)) || {
+    log "Skipping desktop integration changes"
+    return 0
+  }
+
+  disable_waybar_conflicts
+  mute_swaync_popups
+  install_toggle_keybind
+  configure_setup_wizard_behavior
+}
+
 enable_service() {
   if ((ENABLE_SERVICE == 0)); then
     log "Skipping systemd user service enablement because --no-enable-service was passed"
@@ -274,9 +524,10 @@ print_top_bar_note() {
   cat <<'EOF'
 
 ==> Top bar note
-Disable Waybar or any other top bar that reserves the same top screen area before
-using Tide Island. Also choose one startup method: systemd --user or Hyprland
-exec-once, but not both.
+This installer can disable common Waybar startup paths, mute SwayNC popups, add
+a Tide Island service toggle keybind, and set the service to skip the setup
+wizard after installation. If you manage those pieces yourself, rerun with
+--no-desktop-integration or one of the narrower --no-* options.
 EOF
 }
 
@@ -298,6 +549,7 @@ main() {
   check_qt_version
   build_quickshell
   build_tide_island
+  apply_desktop_integration
   enable_service
   print_top_bar_note
   print_final_commands

--- a/tools/tide-island-setup.cpp
+++ b/tools/tide-island-setup.cpp
@@ -969,6 +969,9 @@ void printUsage()
 int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
+    if (!envString("TIDE_ISLAND_SKIP_SETUP").isEmpty())
+        return 0;
+
     const QStringList args = app.arguments().mid(1);
     if (args.size() != 1) {
         printUsage();


### PR DESCRIPTION
- Disable common Waybar startup paths during Debian/Ubuntu install
- Mute SwayNC popups to avoid duplicate Tide Island notifications
- Add Ctrl+Super+Alt+B keybind for toggling the Tide Island user service
- Add a systemd user drop-in to skip repeated setup wizard launches
- Respect TIDE_ISLAND_SKIP_SETUP in the setup helper
- Document the new installer integration options